### PR TITLE
Correct symbol for CHF

### DIFF
--- a/map.json
+++ b/map.json
@@ -95,7 +95,7 @@
 , "KRW": "₩"
 , "LKR": "₨"
 , "SEK": "kr"
-, "CHF": "CHF"
+, "CHF": "Fr."
 , "SRD": "$"
 , "SYP": "£"
 , "TWD": "NT$"


### PR DESCRIPTION
From http://en.wikipedia.org/wiki/Swiss_franc
