### PR TITLE
Change symbol for CHF back to CHF.

### DIFF
--- a/map.json
+++ b/map.json
@@ -94,7 +94,7 @@
 , "ZAR": "R"
 , "LKR": "₨"
 , "SEK": "kr"
-, "CHF": "Fr."
+, "CHF": "CHF"
 , "SRD": "$"
 , "SYP": "£"
 , "TZS": "TSh"


### PR DESCRIPTION
Unicode CLDR uses CHF as the currency symbol for CHF (code) in all locales. (CLDR stores currency symbols at the locale level.)

To check:
```
git clone git@github.com:unicode-cldr/cldr-numbers-modern.git
cd cldr-numbers-modern
grep -lIR '"CHF":' main | wc -l
grep -lIR '"symbol": "CHF"' main | wc -l
```
The output of the two `grep` commands should be the same (352 at the moment).