### PR TITLE
Rename map.json to map.js

### DIFF
--- a/currency-symbol-map.js
+++ b/currency-symbol-map.js
@@ -1,6 +1,6 @@
 module.exports = mapSymbol
 
-var map = require('./map.json')
+var map = require('./map')
 
 function mapSymbol(currencyCode) {
   if (map.hasOwnProperty(currencyCode)) {

--- a/map.js
+++ b/map.js
@@ -1,4 +1,5 @@
-{ "ALL": "L"
+module.exports = {
+  "ALL": "L"
 , "AFN": "؋"
 , "ARS": "$"
 , "AWG": "ƒ"


### PR DESCRIPTION
Hi! I opened this pull request because in webpack projects module parse failed and need an appropriate loader to handle json file type.