### PR TITLE
added turkish lira symbol

### DIFF
--- a/map.js
+++ b/map.js
@@ -102,7 +102,7 @@ module.exports =
 , "TWD": "NT$"
 , "THB": "฿"
 , "TTD": "TT$"
-, "TRY": ""
+, "TRY": "₺"
 , "TRL": "₤"
 , "TVD": "$"
 , "UGX": "USh"


### PR DESCRIPTION
Adding missing turkish lira symbol 

Refrences:
[Turkish lira wiki](https://en.wikipedia.org/wiki/Turkish_lira)
[Central Bank of Turkey](http://www.tcmb.gov.tr/wps/wcm/connect/TCMB+EN/TCMB+EN/Bottom+Menu/Other/Turkish+Lira+Sign)
[xe.com refrence](http://www.xe.com/currency/try-turkish-lira)
