### PR TITLE
Add amd jod kwd lyd

### DIFF
--- a/map.js
+++ b/map.js
@@ -79,6 +79,7 @@ module.exports = {
   'KMF': 'CF',
   'KPW': '₩',
   'KRW': '₩',
+  'KWD': 'KD',
   'KYD': '$',
   'KZT': '₸',
   'LAK': '₭',

--- a/map.js
+++ b/map.js
@@ -88,6 +88,7 @@ module.exports = {
   'LTC': 'Ł',
   'LTL': 'Lt',
   'LVL': 'Ls',
+  'LYD': 'LD',
   'MAD': 'MAD',
   'MDL': 'lei',
   'MGA': 'Ar',

--- a/map.js
+++ b/map.js
@@ -71,6 +71,7 @@ module.exports = {
   'ISK': 'kr',
   'JEP': '£',
   'JMD': 'J$',
+  'JOD': 'JD',
   'JPY': '¥',
   'KES': 'KSh',
   'KGS': 'лв',

--- a/map.js
+++ b/map.js
@@ -2,6 +2,7 @@ module.exports = {
   'AED': 'د.إ',
   'AFN': '؋',
   'ALL': 'L',
+  'AMD': 'AMD',
   'ANG': 'ƒ',
   'AOA': 'Kz',
   'ARS': '$',


### PR DESCRIPTION
## Sources

https://en.wikipedia.org/wiki/Jordanian_dinar
https://en.wikipedia.org/wiki/Kuwaiti_dinar
https://en.wikipedia.org/wiki/Libyan_dinar
https://en.wikipedia.org/wiki/Armenian_dram

## Note
AMD symbol hasn't been included in UTF-8 standard yet and it doesn't have a simple abbreviation, so I just duplicated the currency code.