### PR TITLE
Add Mauritanian ouguiya (MRO)

### DIFF
--- a/map.js
+++ b/map.js
@@ -99,6 +99,7 @@ module.exports = {
   'MMK': 'K',
   'MNT': '₮',
   'MOP': 'MOP$',
+  'MRO': 'UM',
   'MUR': '₨',
   'MVR': 'Rf',
   'MWK': 'MK',


### PR DESCRIPTION
It's one of the currencies supported by Stripe, which is why I noticed it was missing.

Sources:
- [Wikipedia](https://en.wikipedia.org/wiki/Mauritanian_ouguiya)
- [Lonely Planet](https://www.lonelyplanet.com/mauritania/money-costs)