### PR TITLE
Add Venezuelan Bolivar Soberano

### DIFF
--- a/map.js
+++ b/map.js
@@ -161,6 +161,7 @@ module.exports = {
   'UYU': '$U',
   'UZS': 'лв',
   'VEF': 'Bs',
+  'VES': 'Bs.S',
   'VND': '₫',
   'VUV': 'VT',
   'WST': 'WS$',


### PR DESCRIPTION
>The bolívar soberano (sign: Bs.S.[1] or Bs.;[5] plural: bolívares soberanos; ISO 4217 code: VES) is the main currency of Venezuela since 20 August 2018.

[Wikipedia](https://en.wikipedia.org/wiki/Venezuelan_bol%C3%ADvar)