### PR TITLE
Corrected Bitcoin Symbol

### DIFF
--- a/map.js
+++ b/map.js
@@ -20,7 +20,7 @@ module.exports = {
   'BOB': '$b',
   'BRL': 'R$',
   'BSD': '$',
-  'BTC': '฿',
+  'BTC': '₿',
   'BTN': 'Nu.',
   'BWP': 'P',
   'BYR': 'Br',


### PR DESCRIPTION
The symbol mapped to BTC was the same as THB (Thai Baht). This utilizes the correct unicode symbol for BTC. Resolves #49.