### PR TITLE
Fix currency symbol for KZT (Kazakhstani Tenge)

### DIFF
--- a/map.js
+++ b/map.js
@@ -83,7 +83,7 @@ module.exports = {
   'KRW': '₩',
   'KWD': 'KD',
   'KYD': '$',
-  'KZT': 'лв',
+  'KZT': '₸',
   'LAK': '₭',
   'LBP': '£',
   'LKR': '₨',


### PR DESCRIPTION
The currency symbol for Kazakhstani tenge is incorrect