### PR TITLE
Fix Romanian leu symbol

### DIFF
--- a/map.js
+++ b/map.js
@@ -124,7 +124,7 @@ module.exports = {
   'PYG': 'Gs',
   'QAR': '﷼',
   'RMB': '￥',
-  'RON': 'lei',
+  'RON': 'L',
   'RSD': 'Дин.',
   'RUB': '₽',
   'RWF': 'R₣',


### PR DESCRIPTION
According to Wikipedia please use sign: L; https://en.wikipedia.org/wiki/Romanian_leu