### PR TITLE
Add CNH Currency mapping

### DIFF
--- a/map.js
+++ b/map.js
@@ -34,6 +34,7 @@ module.exports = {
   CHW: 'CHW',
   CLF: 'CLF',
   CLP: '$',
+  CNH: '¥',
   CNY: '¥',
   COP: '$',
   COU: 'COU',


### PR DESCRIPTION
Adding CNH Currency mapping, as CNH is the Chinese Yuan traded in the offshore market.

Ref: https://wise.com/us/blog/cny-vs-cnh